### PR TITLE
Fix typo in post install command.

### DIFF
--- a/ng-client/package.json
+++ b/ng-client/package.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "angular-cli": {},
   "scripts": {
-    "start": "./node_modules/.bin/ng serve",
-    "postinstall": "./node_moduels/.bin/typings install",
+    "start": "ng serve",
+    "postinstall": "typings install",
     "lint": "tslint \"src/**/*.ts\"",
     "test": "ng test",
     "pree2e": "webdriver-manager update",


### PR DESCRIPTION
moduels. shouldn't need the prefixes either.
