### PR TITLE
add prestart command to remove tmp directory

### DIFF
--- a/ng-client/package.json
+++ b/ng-client/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "angular-cli": {},
   "scripts": {
+    "prestart": "rm -rf ./tmp",
     "start": "ng serve",
     "lint": "tslint \"src/**/*.ts\"",
     "test": "ng test",


### PR DESCRIPTION
Temp fix for what seems like a windows bug described here: https://github.com/angular/angular-cli/issues/1557
