### PR TITLE
build: use rimraf to remove tmp folder before start

### DIFF
--- a/ng-client/package.json
+++ b/ng-client/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "angular-cli": {},
   "scripts": {
+    "prestart": "rimraf tmp",
     "start": "ng serve",
     "lint": "tslint \"src/**/*.ts\"",
     "test": "ng test",
@@ -49,6 +50,7 @@
     "karma-coverage": "1.0.0",
     "karma-jasmine": "0.3.8",
     "protractor": "3.3.0",
+    "rimraf": "^2.5.4",
     "ts-node": "1.2.1",
     "tslint": "3.13.0",
     "typescript": "2.0.0"


### PR DESCRIPTION
We should probably use rimraf rather than `rm -rf` for better cross platform support (looking at you windows).

Similar functionality as #61
